### PR TITLE
Added customerid option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ oauthdoctor -language python -oauthtype installed_app -configpath /my/path
 -verbose
 ```
 
+You can specify customer ID in advance with the -customerid option.
+
+```
+oauthdoctor -language python -oauthtype installed_app -customerid 123-456-7890
+```
+
 -sysinfo prints the system information to stdout. This is primarily of use if
 you need to send the output of the program when contacting support.
 

--- a/oauthdoctor/oauthdoctor.go
+++ b/oauthdoctor/oauthdoctor.go
@@ -29,6 +29,7 @@ var (
 	language   = flag.String("language", "", "Required: The programming language of Google Ads API client library")
 	oauthType  = flag.String("oauthtype", "Required: The OAuth2 type for Google Ads API.", fmt.Sprintf("Values: %s", strings.Join(oauthTypes, ", ")))
 	configPath = flag.String("configpath", "", "Optional: An absolute file path for Google Ads API configuration file")
+	customerID = flag.String("customerid", "", "Optional: Specify customer Id without reading from prompt")
 	hidePII    = flag.Bool("hidepii", true, "Optional: Suppress output of Personally Identifiable Information")
 	sysinfo    = flag.Bool("sysinfo", false, "Optional: Print system information.")
 	verbose    = flag.Bool("verbose", false, "Optional: Print out debugging info, such as JSON response")
@@ -101,7 +102,11 @@ func main() {
 		log.Printf("Config file validation failed: %s\n", err)
 	}
 
-	cid := oauth.ReadCustomerID()
+	cid := strings.ReplaceAll(*customerID, "-", "")
+	if cid == "" {
+		cid = oauth.ReadCustomerID()
+	}
+
 	c := oauth.Config{
 		ConfigFile: cfg,
 		CustomerID: cid,


### PR DESCRIPTION
First, thanks for nice application!

In our company, MCC accounts are managed by non-engineers. Therefore, we added the customerid option for minimal operation.
```console
oauthdoctor -language python -oauthtype installed_app -customerid 123-456-7890
```

Feel free to reject this PR if it doesn't fit your thoughts 😄 

Best regards,